### PR TITLE
Fix jekyll link

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,1 +1,1 @@
-<footer><span>Built with <a href="jekyllrb.com"><font color="white">Jekyll</font></a> - Template by <a href="https://github.com/KingFelix/emerald"><font color="white">Emerald</font></a></span></footer>
+<footer><span>Built with <a href="http://jekyllrb.com/"><font color="white">Jekyll</font></a> - Template by <a href="https://github.com/KingFelix/emerald"><font color="white">Emerald</font></a></span></footer>


### PR DESCRIPTION
Hey I noticed the footer on your github page has a broken link to jekyllrb.com. Here's a fix!